### PR TITLE
[cli] Fix the UAF with by-value receivers and `--weak-refs`

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -124,15 +124,14 @@ impl<'a, 'b> Builder<'a, 'b> {
                 drop(params.next());
                 if js.cx.config.debug {
                     js.prelude(
-                        "if (this.ptr == 0) throw new Error('Attempt to use a moved value');\n",
+                        "if (this.ptr == 0) throw new Error('Attempt to use a moved value');",
                     );
                 }
                 if consumes_self {
-                    js.prelude("var ptr = this.ptr;");
-                    js.prelude("this.ptr = 0;");
-                    js.args.push("ptr".to_string());
+                    js.prelude("const ptr = this.__destroy_into_raw();");
+                    js.args.push("ptr".into());
                 } else {
-                    js.args.push("this.ptr".to_string());
+                    js.args.push("this.ptr".into());
                 }
             }
             None => {}

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -846,10 +846,15 @@ impl<'a> Context<'a> {
 
         dst.push_str(&format!(
             "
-            free() {{
+            __destroy_into_raw() {{
                 const ptr = this.ptr;
                 this.ptr = 0;
                 {}
+                return ptr;
+            }}
+
+            free() {{
+                const ptr = this.__destroy_into_raw();
                 wasm.{}(ptr);
             }}
             ",


### PR DESCRIPTION
Fixes https://github.com/rustwasm/wasm-bindgen/issues/2447

@konstantinbe @hamchapman While waiting for the official PR to be fixed, feel free to use this branch in the meantime: replace the following step in the `jakefile`:

```bash
cargo install -f --version 0.2.69 wasm-bindgen-cli
```

with:

```bash
cargo install -f --version 0.2.69 wasm-bindgen-cli \
    --git https://github.com/getditto/wasm-bindgen \
    --branch ditto/fix-weak-refs-UAF-with-by-value-receivers
```

(This PR is not the public one (`https://github.com/rustwasm/wasm-bindgen/pull/2448`) since it is based off the `0.2.69` tag we were using, it's just there for us to have a maximally compatible patch to use in our pipeline 🙂)

cc @mbalex99 